### PR TITLE
Fix for Clang 17, libstdc++13  and  a bunch of warnings

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -6,7 +6,7 @@ from conans.tools import Version
 
 class CAFConan(ConanFile):
     name = "caf"
-    version = "0.17.4-lmx.12"
+    version = "0.17.4-lmx.13"
     description = "An open source implementation of the Actor Model in C++"
     url = "https://github.com/bincrafters/conan-caf"
     homepage = "https://github.com/actor-framework/actor-framework"

--- a/examples/remoting/distributed_calculator.cpp
+++ b/examples/remoting/distributed_calculator.cpp
@@ -270,7 +270,7 @@ void client_repl(actor_system& system, const config& cfg) {
           cout << R"(")" << arg2 << R"(" > )"
                << std::numeric_limits<uint16_t>::max() << endl;
         else
-          anon_send(client, connect_atom::value, move(arg1),
+          anon_send(client, connect_atom::value, std::move(arg1),
                     static_cast<uint16_t>(lport));
       }
       else {

--- a/libcaf_core/caf/blocking_actor.hpp
+++ b/libcaf_core/caf/blocking_actor.hpp
@@ -334,7 +334,7 @@ public:
   template <class... Ts>
   do_receive_helper do_receive(Ts&&... xs) {
     auto tup = std::make_tuple(std::forward<Ts>(xs)...);
-    auto cb = [=](receive_cond& rc) mutable {
+    auto cb = [=, this](receive_cond& rc) mutable {
       varargs_tup_receive(rc, make_message_id(), tup);
     };
     return {cb};

--- a/libcaf_core/caf/composable_behavior.hpp
+++ b/libcaf_core/caf/composable_behavior.hpp
@@ -46,7 +46,7 @@ public:
   // C++14 and later
 #if __cplusplus > 201103L
   auto make_callback() {
-    return [=](param_t<Xs>... xs) { return (*this)(std::move(xs)...); };
+    return [=, this](param_t<Xs>... xs) { return (*this)(std::move(xs)...); };
   }
 #else
   // C++11

--- a/libcaf_core/caf/detail/atom_val.hpp
+++ b/libcaf_core/caf/detail/atom_val.hpp
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace caf {
 namespace detail {
 

--- a/libcaf_core/caf/detail/ripemd_160.hpp
+++ b/libcaf_core/caf/detail/ripemd_160.hpp
@@ -56,6 +56,7 @@
 
 #include <array>
 #include <string>
+#include <cstdint>
 
 namespace caf {
 namespace detail {

--- a/libcaf_core/caf/detail/split_join.hpp
+++ b/libcaf_core/caf/detail/split_join.hpp
@@ -47,13 +47,13 @@ public:
   }
 
   behavior make_behavior() override {
-    auto f = [=](scheduled_actor*, message_view& xs) -> result<message> {
+    auto f = [=, this](scheduled_actor*, message_view& xs) -> result<message> {
       auto msg = xs.move_content_to_message();
       auto rp = this->make_response_promise();
       split_(workset_, msg);
       for (auto& x : workset_)
         this->send(x.first, std::move(x.second));
-      auto g = [=](scheduled_actor*, message_view& ys) mutable
+      auto g = [=, this](scheduled_actor*, message_view& ys) mutable
                -> result<message> {
         auto res = ys.move_content_to_message();
         join_(value_, res);

--- a/libcaf_core/caf/input_range.hpp
+++ b/libcaf_core/caf/input_range.hpp
@@ -35,8 +35,13 @@ public:
   input_range(const input_range&) = default;
   input_range& operator=(const input_range&) = default;
 
-  class iterator : public std::iterator<std::input_iterator_tag, T> {
+  class iterator{
   public:
+    using difference_type = std::ptrdiff_t;
+    using value_type = T;
+    using pointer = T*;
+    using reference = T&;
+    using iterator_category = std::input_iterator_tag;
     iterator(input_range* range) : xs_(range) {
       if (xs_)
         advance();

--- a/libcaf_core/caf/settings.hpp
+++ b/libcaf_core/caf/settings.hpp
@@ -67,8 +67,8 @@ template <class T, class = typename std::enable_if<
 T get_or(const settings& xs, string_view name, T default_value) {
   auto result = get_if<T>(&xs, name);
   if (result)
-    return std::move(*result);
-  return std::move(default_value);
+    return *result;
+  return default_value;
 }
 
 std::string get_or(const settings& xs, string_view name,

--- a/libcaf_core/src/blocking_actor.cpp
+++ b/libcaf_core/src/blocking_actor.cpp
@@ -320,7 +320,7 @@ size_t blocking_actor::attach_functor(const strong_actor_ptr& ptr) {
   if (!ptr)
     return 0;
   actor self{this};
-  ptr->get()->attach_functor([=](const error&) {
+  ptr->get()->attach_functor([=, this](const error&) {
     anon_send(self, wait_for_atom::value);
   });
   return 1;

--- a/libcaf_core/src/detail/get_root_uuid.cpp
+++ b/libcaf_core/src/detail/get_root_uuid.cpp
@@ -120,11 +120,11 @@ std::string get_root_uuid() {
   ifstream fs;
   fs.open("/etc/fstab", std::ios_base::in);
   columns_iterator end;
-  auto i = find_if(columns_iterator{&fs}, end, [](const vector<string>& cols) {
+  auto i = std::find_if(columns_iterator{&fs}, end, [](const vector<string>& cols) {
     return cols.size() == 6 && cols[1] == "/";
   });
   if (i != end) {
-    uuid = move((*i)[0]);
+    uuid = std::move((*i)[0]);
     const char cstr[] = {"UUID="};
     auto slen = sizeof(cstr) - 1;
     if (uuid.compare(0, slen, cstr) == 0) {

--- a/libcaf_core/src/detail/get_root_uuid.cpp
+++ b/libcaf_core/src/detail/get_root_uuid.cpp
@@ -80,8 +80,12 @@ namespace detail {
 
 namespace {
 
-struct columns_iterator
-  : std::iterator<std::forward_iterator_tag, vector<string>> {
+struct columns_iterator{
+  using difference_type = std::ptrdiff_t;
+  using value_type = vector<string>;
+  using pointer = vector<string>*;
+  using reference = vector<string>&;
+  using iterator_category = std::forward_iterator_tag;
   columns_iterator(ifstream* s = nullptr) : fs(s) {
     // nop
   }

--- a/libcaf_core/src/scheduler/test_coordinator.cpp
+++ b/libcaf_core/src/scheduler/test_coordinator.cpp
@@ -155,17 +155,17 @@ size_t test_coordinator::run(size_t max_count) {
 
 void test_coordinator::inline_next_enqueue() {
   CAF_LOG_TRACE("");
-  after_next_enqueue([=] { run_once_lifo(); });
+  after_next_enqueue([=, this] { run_once_lifo(); });
 }
 
 void test_coordinator::inline_all_enqueues() {
   CAF_LOG_TRACE("");
-  after_next_enqueue([=] { inline_all_enqueues_helper(); });
+  after_next_enqueue([=, this] { inline_all_enqueues_helper(); });
 }
 
 void test_coordinator::inline_all_enqueues_helper() {
   CAF_LOG_TRACE("");
-  after_next_enqueue([=] { inline_all_enqueues_helper(); });
+  after_next_enqueue([=, this] { inline_all_enqueues_helper(); });
   run_once_lifo();
 }
 

--- a/libcaf_core/test/composable_behavior.cpp
+++ b/libcaf_core/test/composable_behavior.cpp
@@ -128,7 +128,7 @@ public:
       [](unit_t&) {
         // nop
       },
-      [=](unit_t&, int x) { buf.emplace_back(x); });
+      [=, this](unit_t&, int x) { buf.emplace_back(x); });
     return unit;
   }
 };

--- a/libcaf_core/test/constructor_attach.cpp
+++ b/libcaf_core/test/constructor_attach.cpp
@@ -33,14 +33,14 @@ using done_atom = atom_constant<atom("done")>;
 class testee : public event_based_actor {
 public:
   testee(actor_config& cfg, actor buddy) : event_based_actor(cfg) {
-    attach_functor([=](const error& reason) {
+    attach_functor([=, this](const error& reason) {
       send(buddy, done_atom::value, reason);
     });
   }
 
   behavior make_behavior() override {
     return {
-      [=](die_atom) {
+      [=, this](die_atom) {
         quit(exit_reason::user_shutdown);
       }
     };
@@ -53,7 +53,7 @@ public:
       : event_based_actor(cfg),
         downs_(0),
         testee_(spawn<testee, monitored>(this)) {
-    set_down_handler([=](down_msg& msg) {
+    set_down_handler([=, this](down_msg& msg) {
       CAF_CHECK_EQUAL(msg.reason, exit_reason::user_shutdown);
       CAF_CHECK_EQUAL(msg.source, testee_.address());
       if (++downs_ == 2)
@@ -63,13 +63,13 @@ public:
 
   behavior make_behavior() override {
     return {
-      [=](done_atom, const error& reason) {
+      [=, this](done_atom, const error& reason) {
         CAF_CHECK_EQUAL(reason, exit_reason::user_shutdown);
         if (++downs_ == 2) {
           quit(reason);
         }
       },
-      [=](die_atom x) {
+      [=, this](die_atom x) {
         return delegate(testee_, x);
       }
     };

--- a/libcaf_core/test/dynamic_spawn.cpp
+++ b/libcaf_core/test/dynamic_spawn.cpp
@@ -61,7 +61,7 @@ public:
   event_testee(actor_config& cfg) : event_based_actor(cfg) {
     inc_actor_instances();
     wait4string.assign(
-      [=](const std::string&) {
+      [=, this](const std::string&) {
         become(wait4int);
       },
       [=](get_atom) {
@@ -69,7 +69,7 @@ public:
       }
     );
     wait4float.assign(
-      [=](float) {
+      [=, this](float) {
         become(wait4string);
       },
       [=](get_atom) {
@@ -77,7 +77,7 @@ public:
       }
     );
     wait4int.assign(
-      [=](int) {
+      [=, this](int) {
         become(wait4float);
       },
       [=](get_atom) {
@@ -113,7 +113,7 @@ actor spawn_event_testee2(scoped_actor& parent) {
     }
     behavior wait4timeout(int remaining) {
       return {
-        after(chrono::milliseconds(1)) >> [=] {
+        after(chrono::milliseconds(1)) >> [=, this] {
           CAF_MESSAGE("remaining: " << to_string(remaining));
           if (remaining == 1) {
             send(parent, ok_atom::value);
@@ -200,7 +200,7 @@ public:
 
   behavior make_behavior() override {
     return {
-      after(chrono::milliseconds(10)) >> [=] {
+      after(chrono::milliseconds(10)) >> [=, this] {
         unbecome();
       }
     };
@@ -478,7 +478,7 @@ CAF_TEST(constructor_attach) {
     testee(actor_config& cfg, actor buddy)
         : event_based_actor(cfg),
           buddy_(buddy) {
-      attach_functor([=](const error& reason) {
+      attach_functor([=, this](const error& reason) {
         send(buddy, ok_atom::value, reason);
       });
     }
@@ -504,19 +504,19 @@ CAF_TEST(constructor_attach) {
         : event_based_actor(cfg),
           downs_(0),
           testee_(spawn<testee, monitored>(this)) {
-      set_down_handler([=](down_msg& msg) {
+      set_down_handler([=, this](down_msg& msg) {
         CAF_CHECK_EQUAL(msg.reason, exit_reason::user_shutdown);
         if (++downs_ == 2)
           quit(msg.reason);
       });
-      set_exit_handler([=](exit_msg& msg) {
+      set_exit_handler([=, this](exit_msg& msg) {
         send_exit(testee_, std::move(msg.reason));
       });
     }
 
     behavior make_behavior() override {
       return {
-        [=](ok_atom, const error& reason) {
+        [=, this](ok_atom, const error& reason) {
           CAF_CHECK_EQUAL(reason, exit_reason::user_shutdown);
           if (++downs_ == 2)
             quit(reason);

--- a/libcaf_core/test/message.cpp
+++ b/libcaf_core/test/message.cpp
@@ -281,7 +281,7 @@ CAF_TEST(strings_to_string) {
 
 CAF_TEST(maps_to_string) {
   map<int, int> m1{{1, 10}, {2, 20}, {3, 30}};
-  auto msg1 = make_message(move(m1));
+  auto msg1 = make_message(std::move(m1));
   CAF_CHECK_EQUAL(to_string(msg1), "({1 = 10, 2 = 20, 3 = 30})");
 }
 

--- a/libcaf_core/test/message_lifetime.cpp
+++ b/libcaf_core/test/message_lifetime.cpp
@@ -57,7 +57,7 @@ public:
       : event_based_actor(cfg),
         aut_(std::move(aut)),
         msg_(make_message(1, 2, 3)) {
-    set_down_handler([=](down_msg& dm) {
+    set_down_handler([=, this](down_msg& dm) {
       CAF_CHECK_EQUAL(dm.reason, exit_reason::normal);
       CAF_CHECK_EQUAL(dm.source, aut_.address());
       quit();

--- a/libcaf_core/test/mixin/requester.cpp
+++ b/libcaf_core/test/mixin/requester.cpp
@@ -84,8 +84,8 @@ CAF_TEST_FIXTURE_SCOPE(requester_tests, fixture)
 CAF_TEST(requests without result) {
   auto server = discarding_server;
   SUBTEST("request.then") {
-    auto client = sys.spawn([=](event_based_actor* self) {
-      self->request(server, infinite, 1, 2).then([=] { *result = unit; });
+    auto client = sys.spawn([=, this](event_based_actor* self) {
+      self->request(server, infinite, 1, 2).then([=, this] { *result = unit; });
     });
     run_once();
     expect((int, int), from(client).to(server).with(1, 2));
@@ -93,8 +93,8 @@ CAF_TEST(requests without result) {
     CAF_CHECK_EQUAL(*result, unit);
   }
   SUBTEST("request.await") {
-    auto client = sys.spawn([=](event_based_actor* self) {
-      self->request(server, infinite, 1, 2).await([=] { *result = unit; });
+    auto client = sys.spawn([=, this](event_based_actor* self) {
+      self->request(server, infinite, 1, 2).await([=, this] { *result = unit; });
     });
     run_once();
     expect((int, int), from(client).to(server).with(1, 2));
@@ -112,8 +112,8 @@ CAF_TEST(requests without result) {
 CAF_TEST(requests with integer result) {
   auto server = adding_server;
   SUBTEST("request.then") {
-    auto client = sys.spawn([=](event_based_actor* self) {
-      self->request(server, infinite, 1, 2).then([=](int x) { *result = x; });
+    auto client = sys.spawn([=, this](event_based_actor* self) {
+      self->request(server, infinite, 1, 2).then([=, this](int x) { *result = x; });
     });
     run_once();
     expect((int, int), from(client).to(server).with(1, 2));
@@ -121,8 +121,8 @@ CAF_TEST(requests with integer result) {
     CAF_CHECK_EQUAL(*result, 3);
   }
   SUBTEST("request.await") {
-    auto client = sys.spawn([=](event_based_actor* self) {
-      self->request(server, infinite, 1, 2).await([=](int x) { *result = x; });
+    auto client = sys.spawn([=, this](event_based_actor* self) {
+      self->request(server, infinite, 1, 2).await([=, this](int x) { *result = x; });
     });
     run_once();
     expect((int, int), from(client).to(server).with(1, 2));
@@ -140,8 +140,8 @@ CAF_TEST(requests with integer result) {
 CAF_TEST(delegated request with integer result) {
   auto worker = adding_server;
   auto server = make_delegator(worker);
-  auto client = sys.spawn([=](event_based_actor* self) {
-    self->request(server, infinite, 1, 2).then([=](int x) { *result = x; });
+  auto client = sys.spawn([=, this](event_based_actor* self) {
+    self->request(server, infinite, 1, 2).then([=, this](int x) { *result = x; });
   });
   run_once();
   expect((int, int), from(client).to(server).with(1, 2));

--- a/libcaf_core/test/serialization.cpp
+++ b/libcaf_core/test/serialization.cpp
@@ -536,7 +536,7 @@ SERIALIZATION_TEST(non_empty_vector) {
 
 SERIALIZATION_TEST(variant_with_tree_types) {
   CAF_MESSAGE("deserializing into a non-empty vector overrides any content");
-  using test_variant = variant<int, double, std::string>;
+  using test_variant = caf::variant<int, double, std::string>;
   test_variant x{42};
   CAF_CHECK_EQUAL(x, roundtrip(x));
   x = 12.34;

--- a/libcaf_core/test/typed_response_promise.cpp
+++ b/libcaf_core/test/typed_response_promise.cpp
@@ -53,12 +53,12 @@ public:
 
   behavior_type make_behavior() override {
     return {
-      [=](int x) -> foo_promise {
+      [=, this](int x) -> foo_promise {
          auto resp = response(x * 2);
          CAF_CHECK(!resp.pending());
          return resp.deliver(x * 4); // has no effect
       },
-      [=](get_atom, int x) -> foo_promise {
+      [=, this](get_atom, int x) -> foo_promise {
         auto calculator = spawn([]() -> get1_helper::behavior_type {
           return {
             [](int promise_id, int value) -> result<put_atom, int, int> {
@@ -71,7 +71,7 @@ public:
         entry = make_response_promise<foo_promise>();
         return entry;
       },
-      [=](get_atom, int x, int y) -> foo2_promise {
+      [=, this](get_atom, int x, int y) -> foo2_promise {
         auto calculator = spawn([]() -> get2_helper::behavior_type {
           return {
             [](int promise_id, int v0, int v1) -> result<put_atom, int, int, int> {
@@ -92,21 +92,21 @@ public:
         CAF_CHECK(!tmp.pending());
         return entry;
       },
-      [=](get_atom, double) -> foo3_promise {
+      [=, this](get_atom, double) -> foo3_promise {
         auto resp = make_response_promise<double>();
         return resp.deliver(make_error(sec::unexpected_message));
       },
-      [=](get_atom, double x, double y) {
+      [=, this](get_atom, double x, double y) {
         return response(x * 2, y * 2);
       },
-      [=](put_atom, int promise_id, int x) {
+      [=, this](put_atom, int promise_id, int x) {
         auto i = promises_.find(promise_id);
         if (i == promises_.end())
           return;
         i->second.deliver(x);
         promises_.erase(i);
       },
-      [=](put_atom, int promise_id, int x, int y) {
+      [=, this](put_atom, int promise_id, int x, int y) {
         auto i = promises2_.find(promise_id);
         if (i == promises2_.end())
           return;

--- a/libcaf_core/test/typed_spawn.cpp
+++ b/libcaf_core/test/typed_spawn.cpp
@@ -134,7 +134,7 @@ public:
   behavior_type wait4string() {
     return {
       [=](const get_state_msg&) { return "wait4string"; },
-      [=](const string&) { become(wait4int()); },
+      [=, this](const string&) { become(wait4int()); },
       [=](float) { return skip(); },
       [=](int) { return skip(); },
     };
@@ -143,7 +143,7 @@ public:
   behavior_type wait4int() {
     return {
       [=](const get_state_msg&) { return "wait4int"; },
-      [=](int) -> int {
+      [=, this](int) -> int {
         become(wait4float());
         return 42;
       },
@@ -155,7 +155,7 @@ public:
   behavior_type wait4float() {
     return {
       [=](const get_state_msg&) { return "wait4float"; },
-      [=](float) { become(wait4string()); },
+      [=, this](float) { become(wait4string()); },
       [=](const string&) { return skip(); },
       [=](int) { return skip(); },
     };

--- a/libcaf_core/test/variant.cpp
+++ b/libcaf_core/test/variant.cpp
@@ -81,7 +81,7 @@ struct tostring_visitor : static_visitor<string> {
 macro_repeat20(i_n)
 
 // a variant with 20 element types
-using v20 = variant<i01, i02, i03, i04, i05, i06, i07, i08, i09, i10,
+using v20 = caf::variant<i01, i02, i03, i04, i05, i06, i07, i08, i09, i10,
                     i11, i12, i13, i14, i15, i16, i17, i18, i19, i20>;
 
 #define announce_n(n) cfg.add_message_type<i##n>(CAF_STR(i##n));
@@ -117,9 +117,9 @@ CAF_TEST(copying_moving_roundtrips) {
   macro_repeat20(announce_n)
   actor_system sys{cfg};
   // default construction
-  variant<none_t> x1;
+  caf::variant<none_t> x1;
   CAF_CHECK_EQUAL(x1, none);
-  variant<int, none_t> x2;
+  caf::variant<int, none_t> x2;
   CAF_CHECK_EQUAL(x2, 0);
   v20 x3;
   CAF_CHECK_EQUAL(x3, i01{0});
@@ -139,11 +139,11 @@ struct test_visitor {
 } // namespace
 
 CAF_TEST(constructors) {
-  variant<int, string> a{42};
-  variant<string, atom_value> b{atom("foo")};
-  variant<float, int, string> c{string{"bar"}};
-  variant<int, string, double> d{123};
-  variant<bool, uint8_t> e{uint8_t{252}};
+  caf::variant<int, string> a{42};
+  caf::variant<string, atom_value> b{atom("foo")};
+  caf::variant<float, int, string> c{string{"bar"}};
+  caf::variant<int, string, double> d{123};
+  caf::variant<bool, uint8_t> e{uint8_t{252}};
   CAF_CHECK_EQUAL(a, 42);
   CAF_CHECK_EQUAL(b, atom("foo"));
   CAF_CHECK_EQUAL(d, 123);
@@ -152,10 +152,10 @@ CAF_TEST(constructors) {
 }
 
 CAF_TEST(n_ary_visit) {
-  variant<int, string> a{42};
-  variant<string, atom_value> b{atom("foo")};
-  variant<float, int, string> c{string{"bar"}};
-  variant<int, string, double> d{123};
+  caf::variant<int, string> a{42};
+  caf::variant<string, atom_value> b{atom("foo")};
+  caf::variant<float, int, string> c{string{"bar"}};
+  caf::variant<int, string, double> d{123};
   test_visitor f;
   CAF_CHECK_EQUAL(visit(f, a, b), "(42, 'foo')");
   CAF_CHECK_EQUAL(visit(f, a, b, c), "(42, 'foo', \"bar\")");
@@ -163,7 +163,7 @@ CAF_TEST(n_ary_visit) {
 }
 
 CAF_TEST(get_if) {
-  variant<int ,string, atom_value> b = atom("foo");
+  caf::variant<int ,string, atom_value> b = atom("foo");
   CAF_MESSAGE("test get_if directly");
   CAF_CHECK_EQUAL(get_if<int>(&b), nullptr);
   CAF_CHECK_EQUAL(get_if<string>(&b), nullptr);
@@ -175,7 +175,7 @@ CAF_TEST(get_if) {
 }
 
 CAF_TEST(less_than) {
-  using variant_type = variant<char, int>;
+  using variant_type = caf::variant<char, int>;
   auto a = variant_type{'x'};
   auto b = variant_type{'y'};
   CAF_CHECK(a < b);
@@ -196,7 +196,7 @@ CAF_TEST(less_than) {
 }
 
 CAF_TEST(equality) {
-  variant<uint16_t, int> x = 42;
-  variant<uint16_t, int> y = uint16_t{42};
+  caf::variant<uint16_t, int> x = 42;
+  caf::variant<uint16_t, int> y = uint16_t{42};
   CAF_CHECK_NOT_EQUAL(x, y);
 }

--- a/libcaf_io/caf/io/network/datagram_handler.hpp
+++ b/libcaf_io/caf/io/network/datagram_handler.hpp
@@ -74,7 +74,7 @@ public:
   /// @warning Must not be modified outside the IO multiplexers event loop
   ///          once the stream has been started.
   void enqueue_datagram(datagram_handle hdl, std::vector<char> buf) {
-    wr_offline_buf_.emplace_back(hdl, move(buf));
+    wr_offline_buf_.emplace_back(hdl, std::move(buf));
   }
 
   /// Returns the read buffer of this stream.

--- a/libcaf_io/caf/io/network/receive_buffer.hpp
+++ b/libcaf_io/caf/io/network/receive_buffer.hpp
@@ -21,6 +21,7 @@
 #include <cstddef>
 #include <cstring>
 #include <memory>
+#include <limits>
 
 #include "caf/allowed_unsafe_message_type.hpp"
 

--- a/libcaf_io/src/io/basp_broker.cpp
+++ b/libcaf_io/src/io/basp_broker.cpp
@@ -122,7 +122,7 @@ behavior basp_broker::make_behavior() {
   }
   return behavior{
     // received from underlying broker implementation
-    [=](new_data_msg& msg) {
+    [=, this](new_data_msg& msg) {
       CAF_LOG_TRACE(CAF_ARG(msg.handle));
       set_context(msg.handle);
       auto& ctx = *this_context;
@@ -141,7 +141,7 @@ behavior basp_broker::make_behavior() {
       }
     },
     // received from proxy instances
-    [=](forward_atom, strong_actor_ptr& src,
+    [=, this](forward_atom, strong_actor_ptr& src,
         const std::vector<strong_actor_ptr>& fwd_stack, strong_actor_ptr& dest,
         message_id mid, const message& msg) {
       CAF_LOG_TRACE(CAF_ARG(src)
@@ -162,7 +162,7 @@ behavior basp_broker::make_behavior() {
       }
     },
     // received from some system calls like whereis
-    [=](forward_atom, const node_id& dest_node, atom_value dest_name,
+    [=, this](forward_atom, const node_id& dest_node, atom_value dest_name,
         const message& msg) -> result<message> {
       auto cme = current_mailbox_element();
       if (cme == nullptr || cme->sender == nullptr)
@@ -184,7 +184,7 @@ behavior basp_broker::make_behavior() {
     },
     // received from proxy instances to signal that we need to send a BASP
     // monitor_message to the origin node
-    [=](monitor_atom, const strong_actor_ptr& proxy) {
+    [=, this](monitor_atom, const strong_actor_ptr& proxy) {
       if (proxy == nullptr) {
         CAF_LOG_WARNING("received a monitor message from an invalid proxy");
         return;
@@ -203,7 +203,7 @@ behavior basp_broker::make_behavior() {
       flush(hdl);
     },
     // received from underlying broker implementation
-    [=](const new_connection_msg& msg) {
+    [=, this](const new_connection_msg& msg) {
       CAF_LOG_TRACE(CAF_ARG(msg.handle));
       auto& bi = instance;
       bi.write_server_handshake(context(), get_buffer(msg.handle),
@@ -212,7 +212,7 @@ behavior basp_broker::make_behavior() {
       configure_read(msg.handle, receive_policy::exactly(basp::header_size));
     },
     // received from underlying broker implementation
-    [=](const connection_closed_msg& msg) {
+    [=, this](const connection_closed_msg& msg) {
       CAF_LOG_TRACE(CAF_ARG(msg.handle));
       // We might still have pending messages from this connection. To
       // make sure there's no BASP worker deserializing a message, we are
@@ -226,11 +226,11 @@ behavior basp_broker::make_behavior() {
                                   delete_atom::value, msg.handle));
     },
     // received from the message handler above for connection_closed_msg
-    [=](delete_atom, connection_handle hdl) {
+    [=, this](delete_atom, connection_handle hdl) {
       connection_cleanup(hdl, sec::none);
     },
     // received from underlying broker implementation
-    [=](const acceptor_closed_msg& msg) {
+    [=, this](const acceptor_closed_msg& msg) {
       CAF_LOG_TRACE("");
       // Same reasoning as in connection_closed_msg.
       auto& q = instance.queue();
@@ -240,12 +240,12 @@ behavior basp_broker::make_behavior() {
                                   delete_atom::value, msg.handle));
     },
     // received from the message handler above for acceptor_closed_msg
-    [=](delete_atom, accept_handle hdl) {
+    [=, this](delete_atom, accept_handle hdl) {
       auto port = local_port(hdl);
       instance.remove_published_actor(port);
     },
     // received from middleman actor
-    [=](publish_atom, doorman_ptr& ptr, uint16_t port,
+    [=, this](publish_atom, doorman_ptr& ptr, uint16_t port,
         const strong_actor_ptr& whom, std::set<std::string>& sigs) {
       CAF_LOG_TRACE(CAF_ARG(ptr)
                     << CAF_ARG(port) << CAF_ARG(whom) << CAF_ARG(sigs));
@@ -256,7 +256,7 @@ behavior basp_broker::make_behavior() {
       instance.add_published_actor(port, whom, std::move(sigs));
     },
     // received from test code to set up two instances without doorman
-    [=](publish_atom, scribe_ptr& ptr, uint16_t port,
+    [=, this](publish_atom, scribe_ptr& ptr, uint16_t port,
         const strong_actor_ptr& whom, std::set<std::string>& sigs) {
       CAF_LOG_TRACE(CAF_ARG(ptr)
                     << CAF_ARG(port) << CAF_ARG(whom) << CAF_ARG(sigs));
@@ -272,7 +272,7 @@ behavior basp_broker::make_behavior() {
       configure_read(hdl, receive_policy::exactly(basp::header_size));
     },
     // received from middleman actor (delegated)
-    [=](connect_atom, scribe_ptr& ptr, uint16_t port) {
+    [=, this](connect_atom, scribe_ptr& ptr, uint16_t port) {
       CAF_LOG_TRACE(CAF_ARG(ptr) << CAF_ARG(port));
       CAF_ASSERT(ptr != nullptr);
       auto rp = make_response_promise();
@@ -286,17 +286,17 @@ behavior basp_broker::make_behavior() {
       // await server handshake
       configure_read(hdl, receive_policy::exactly(basp::header_size));
     },
-    [=](delete_atom, const node_id& nid, actor_id aid) {
+    [=, this](delete_atom, const node_id& nid, actor_id aid) {
       CAF_LOG_TRACE(CAF_ARG(nid) << ", " << CAF_ARG(aid));
       proxies().erase(nid, aid);
     },
     // received from the BASP instance when receiving down_message
-    [=](delete_atom, const node_id& nid, actor_id aid, error& fail_state) {
+    [=, this](delete_atom, const node_id& nid, actor_id aid, error& fail_state) {
       CAF_LOG_TRACE(CAF_ARG(nid)
                     << ", " << CAF_ARG(aid) << ", " << CAF_ARG(fail_state));
       proxies().erase(nid, aid, std::move(fail_state));
     },
-    [=](unpublish_atom, const actor_addr& whom, uint16_t port) -> result<void> {
+    [=, this](unpublish_atom, const actor_addr& whom, uint16_t port) -> result<void> {
       CAF_LOG_TRACE(CAF_ARG(whom) << CAF_ARG(port));
       auto cb = make_callback(
         [&](const strong_actor_ptr&, uint16_t x) -> error {
@@ -307,7 +307,7 @@ behavior basp_broker::make_behavior() {
         return sec::no_actor_published_at_port;
       return unit;
     },
-    [=](close_atom, uint16_t port) -> result<void> {
+    [=, this](close_atom, uint16_t port) -> result<void> {
       if (port == 0)
         return sec::cannot_close_invalid_port;
       // It is well-defined behavior to not have an actor published here,
@@ -318,7 +318,7 @@ behavior basp_broker::make_behavior() {
         return unit;
       return sec::cannot_close_invalid_port;
     },
-    [=](get_atom,
+    [=, this](get_atom,
         const node_id& x) -> std::tuple<node_id, std::string, uint16_t> {
       std::string addr;
       uint16_t port = 0;
@@ -329,7 +329,7 @@ behavior basp_broker::make_behavior() {
       }
       return std::make_tuple(x, std::move(addr), port);
     },
-    [=](tick_atom, size_t interval) {
+    [=, this](tick_atom, size_t interval) {
       instance.handle_heartbeat(context());
       delayed_send(this, std::chrono::milliseconds{interval}, tick_atom::value,
                    interval);
@@ -358,7 +358,7 @@ strong_actor_ptr basp_broker::make_proxy(node_id nid, actor_id aid) {
   // us a handle to a third node B, then we assume that A offers a route to B
   if (t_last_hop != nullptr && nid != *t_last_hop
       && instance.tbl().add_indirect(*t_last_hop, nid))
-    mm->backend().dispatch([=] { learned_new_node_indirectly(nid); });
+    mm->backend().dispatch([=, this] { learned_new_node_indirectly(nid); });
   // we need to tell remote side we are watching this actor now;
   // use a direct route if possible, i.e., when talking to a third node
   // create proxy and add functor that will be called if we

--- a/libcaf_io/src/io/middleman.cpp
+++ b/libcaf_io/src/io/middleman.cpp
@@ -294,7 +294,7 @@ void middleman::start() {
 
 void middleman::stop() {
   CAF_LOG_TRACE("");
-  backend().dispatch([=] {
+  backend().dispatch([=, this] {
     CAF_LOG_TRACE("");
     // managers_ will be modified while we are stopping each manager,
     // because each manager will call remove(...)
@@ -356,7 +356,7 @@ void middleman::init(actor_system_config& cfg) {
   private:
     middleman& parent_;
   };
-  auto gfactory = [=]() -> group_module* { return new remote_groups(*this); };
+  auto gfactory = [=, this]() -> group_module* { return new remote_groups(*this); };
   cfg.group_module_factories.emplace_back(gfactory);
   // logging not available at this stage
   // add I/O-related types to config

--- a/libcaf_io/src/io/middleman_actor_impl.cpp
+++ b/libcaf_io/src/io/middleman_actor_impl.cpp
@@ -43,7 +43,7 @@ namespace io {
 middleman_actor_impl::middleman_actor_impl(actor_config& cfg,
                                            actor default_broker)
   : middleman_actor::base(cfg), broker_(std::move(default_broker)) {
-  set_down_handler([=](down_msg& dm) {
+  set_down_handler([=, this](down_msg& dm) {
     auto i = cached_tcp_.begin();
     auto e = cached_tcp_.end();
     while (i != e) {
@@ -76,18 +76,18 @@ const char* middleman_actor_impl::name() const {
 auto middleman_actor_impl::make_behavior() -> behavior_type {
   CAF_LOG_TRACE("");
   return {
-    [=](publish_atom, uint16_t port, strong_actor_ptr& whom, mpi_set& sigs,
+    [=, this](publish_atom, uint16_t port, strong_actor_ptr& whom, mpi_set& sigs,
         std::string& addr, bool reuse) -> put_res {
       CAF_LOG_TRACE("");
       return put(port, whom, sigs, addr.c_str(), reuse);
     },
-    [=](open_atom, uint16_t port, std::string& addr, bool reuse) -> put_res {
+    [=, this](open_atom, uint16_t port, std::string& addr, bool reuse) -> put_res {
       CAF_LOG_TRACE("");
       strong_actor_ptr whom;
       mpi_set sigs;
       return put(port, whom, sigs, addr.c_str(), reuse);
     },
-    [=](connect_atom, std::string& hostname, uint16_t port) -> get_res {
+    [=, this](connect_atom, std::string& hostname, uint16_t port) -> get_res {
       CAF_LOG_TRACE(CAF_ARG(hostname) << CAF_ARG(port));
       auto rp = make_response_promise();
       endpoint key{std::move(hostname), port};
@@ -116,7 +116,7 @@ auto middleman_actor_impl::make_behavior() -> behavior_type {
       pending_.emplace(key, std::move(tmp));
       request(broker_, infinite, connect_atom::value, std::move(ptr), port)
         .then(
-          [=](node_id& nid, strong_actor_ptr& addr, mpi_set& sigs) {
+          [=, this](node_id& nid, strong_actor_ptr& addr, mpi_set& sigs) {
             auto i = pending_.find(key);
             if (i == pending_.end())
               return;
@@ -130,7 +130,7 @@ auto middleman_actor_impl::make_behavior() -> behavior_type {
               promise.deliver(res);
             pending_.erase(i);
           },
-          [=](error& err) {
+          [=, this](error& err) {
             auto i = pending_.find(key);
             if (i == pending_.end())
               return;
@@ -140,17 +140,17 @@ auto middleman_actor_impl::make_behavior() -> behavior_type {
           });
       return get_delegated{};
     },
-    [=](unpublish_atom atm, actor_addr addr, uint16_t p) -> del_res {
+    [=, this](unpublish_atom atm, actor_addr addr, uint16_t p) -> del_res {
       CAF_LOG_TRACE("");
       delegate(broker_, atm, std::move(addr), p);
       return {};
     },
-    [=](close_atom atm, uint16_t p) -> del_res {
+    [=, this](close_atom atm, uint16_t p) -> del_res {
       CAF_LOG_TRACE("");
       delegate(broker_, atm, p);
       return {};
     },
-    [=](spawn_atom atm, node_id& nid, std::string& str, message& msg,
+    [=, this](spawn_atom atm, node_id& nid, std::string& str, message& msg,
         std::set<std::string>& ifs) -> delegated<strong_actor_ptr> {
       CAF_LOG_TRACE("");
       delegate(broker_, forward_atom::value, nid, atom("SpawnServ"),
@@ -158,7 +158,7 @@ auto middleman_actor_impl::make_behavior() -> behavior_type {
                             std::move(ifs)));
       return {};
     },
-    [=](get_atom atm,
+    [=, this](get_atom atm,
         node_id nid) -> delegated<node_id, std::string, uint16_t> {
       CAF_LOG_TRACE("");
       delegate(broker_, atm, std::move(nid));

--- a/libcaf_opencl/examples/scan.cpp
+++ b/libcaf_opencl/examples/scan.cpp
@@ -205,7 +205,7 @@ int main() {
   }
   {
     // ---- general ----
-    auto dev = move(*opt);
+    auto dev = std::move(*opt);
     auto prog = mngr.create_program(kernel_source, "", dev);
     scoped_actor self{system};
     // ---- config parameters ----
@@ -243,7 +243,7 @@ int main() {
         return msg.apply([&](uref& data, uref& incs) {
           auto size = incs.size();
           range = nd_conf(size);
-          return make_message(move(data), move(incs), static_cast<uval>(size));
+          return make_message(std::move(data), std::move(incs), static_cast<uval>(size));
         });
       },
       in_out<uval,mref,mref>{},
@@ -256,7 +256,7 @@ int main() {
         return msg.apply([&](uref& data, uref& incs) {
           auto size = incs.size();
           range = nd_conf(size);
-          return make_message(move(data), move(incs), static_cast<uval>(size));
+          return make_message(std::move(data), std::move(incs), static_cast<uval>(size));
         });
       },
       in_out<uval,mref,val>{},

--- a/libcaf_opencl/src/platform.cpp
+++ b/libcaf_opencl/src/platform.cpp
@@ -68,9 +68,9 @@ platform_ptr platform::create(cl_platform_id platform_id,
   auto name = platform_info(platform_id, CL_PLATFORM_NAME);
   auto vendor = platform_info(platform_id, CL_PLATFORM_VENDOR);
   auto version = platform_info(platform_id, CL_PLATFORM_VERSION);
-  return make_counted<platform>(platform_id, move(context), move(name),
-                                move(vendor), move(version),
-                                move(device_information));
+  return make_counted<platform>(platform_id, std::move(context), std::move(name),
+                                std::move(vendor), std::move(version),
+                                std::move(device_information));
 }
 
 string platform::platform_info(cl_platform_id platform_id,
@@ -90,10 +90,10 @@ platform::platform(cl_platform_id platform_id, detail::raw_context_ptr context,
                    vector<device_ptr> devices)
   : platform_id_(platform_id),
     context_(std::move(context)),
-    name_(move(name)),
-    vendor_(move(vendor)),
-    version_(move(version)),
-    devices_(move(devices)) {
+    name_(std::move(name)),
+    vendor_(std::move(vendor)),
+    version_(std::move(version)),
+    devices_(std::move(devices)) {
   // nop
 }
 

--- a/libcaf_test/caf/test/io_dsl.hpp
+++ b/libcaf_test/caf/test/io_dsl.hpp
@@ -75,7 +75,7 @@ public:
     // nop
   }
 
-  test_node_fixture() : test_node_fixture([=] { this->run(); }) {
+  test_node_fixture() : test_node_fixture([=, this] { this->run(); }) {
     // nop
   }
 

--- a/libcaf_test/caf/test/unit_test_impl.hpp
+++ b/libcaf_test/caf/test/unit_test_impl.hpp
@@ -49,7 +49,7 @@ public:
 
 private:
   watchdog(int secs) {
-    thread_ = std::thread{[=] {
+    thread_ = std::thread{[=, this] {
       auto tp =
         std::chrono::high_resolution_clock::now() + std::chrono::seconds(secs);
         std::unique_lock<std::mutex> guard{mtx_};


### PR DESCRIPTION
Fixed the issues with clang 17, libstdc++13, and cleaned up most of the warnings. Please take a look at the individual commits for the details. It passed the tests.

```
+----------------------------------------------------------------------+
                                summary
+----------------------------------------------------------------------+
                        suites:  1
                        tests:   5
                        checks:  74
                        time:    192 ms
                        success: 100%
+----------------------------------------------------------------------+
```